### PR TITLE
onchain registry

### DIFF
--- a/contracts/sources/hooks/weight.move
+++ b/contracts/sources/hooks/weight.move
@@ -10,6 +10,7 @@ module liquid_staking::weight {
     use sui::package;
     use sui::coin::Coin;
     use sui::sui::SUI;
+    use liquid_staking::registry::{Registry};
 
     /* Constants */
     const CURRENT_VERSION: u16 = 1;
@@ -28,6 +29,10 @@ module liquid_staking::weight {
     }
 
     public struct WEIGHT has drop {}
+
+    public struct RegistryInfo has store {
+        weight_hook_id: ID,
+    }
 
     fun init(otw: WEIGHT, ctx: &mut TxContext) {
         package::claim_and_keep(otw, ctx)
@@ -48,6 +53,20 @@ module liquid_staking::weight {
             },
             WeightHookAdminCap { id: object::new(ctx) }
         )
+    }
+
+    public fun add_to_registry<P>(
+        self: &WeightHook<P>,
+        registry: &mut Registry,
+        liquid_staking_info: &LiquidStakingInfo<P>,
+    ) {
+        registry.add_to_registry(
+            &self.admin_cap,
+            liquid_staking_info,
+            RegistryInfo {
+                weight_hook_id: *self.id.as_inner(),
+            }
+        );
     }
 
     public fun set_validator_addresses_and_weights<P>(
@@ -182,5 +201,9 @@ module liquid_staking::weight {
         self.version.assert_version(CURRENT_VERSION);
 
         &self.admin_cap
+    }
+
+    public fun weight_hook_id(self: &RegistryInfo): ID {
+        self.weight_hook_id
     }
 }

--- a/contracts/sources/registry.move
+++ b/contracts/sources/registry.move
@@ -1,0 +1,67 @@
+module liquid_staking::registry {
+    use sui::bag::{Self, Bag};
+    use liquid_staking::liquid_staking::{AdminCap, LiquidStakingInfo};
+    use std::type_name::{Self};
+    use liquid_staking::version::{Self, Version};
+
+    const CURRENT_VERSION: u16 = 1;
+
+    public struct Registry has key, store {
+        id: UID,
+        version: Version,
+        table: Bag, 
+    }
+
+    public struct Entry<ExtraInfoType: store> has copy, store {
+        admin_cap_id: ID,
+        liquid_staking_info_id: ID,
+        extra_info: ExtraInfoType,
+    }
+
+    /* Getter Functions */
+    public fun admin_cap_id<ExtraInfoType: store>(self: &Entry<ExtraInfoType>): ID {
+        self.admin_cap_id
+    }
+
+    public fun liquid_staking_info_id<ExtraInfoType: store>(self: &Entry<ExtraInfoType>): ID {
+        self.liquid_staking_info_id
+    }
+
+    public fun extra_info<ExtraInfoType: store>(self: &Entry<ExtraInfoType>): &ExtraInfoType {
+        &self.extra_info
+    }
+
+    public fun new(ctx: &mut TxContext): Registry {
+        let registry = Registry {
+            id: object::new(ctx),
+            version: version::new(CURRENT_VERSION),
+            table: bag::new(ctx),
+        };
+
+        registry
+    }
+
+    public(package) fun add_to_registry<CoinType, ExtraInfoType: store>(
+        self: &mut Registry,
+        admin_cap: &AdminCap<CoinType>, 
+        liquid_staking_info: &LiquidStakingInfo<CoinType>,
+        extra_info: ExtraInfoType,
+    ) {
+        self.version.assert_version_and_upgrade(CURRENT_VERSION);
+
+        self.table.add(
+            type_name::get<CoinType>(),
+            Entry {
+                admin_cap_id: object::id(admin_cap),
+                liquid_staking_info_id: object::id(liquid_staking_info),
+                extra_info,
+            }
+        );
+    }
+
+    public(package) fun get_entry<CoinType, ExtraInfoType: store>(
+        self: &Registry,
+    ): &Entry<ExtraInfoType> {
+        self.table.borrow(type_name::get<CoinType>())
+    }
+}

--- a/contracts/tests/registry_tests.move
+++ b/contracts/tests/registry_tests.move
@@ -1,0 +1,41 @@
+#[test_only]
+module liquid_staking::registry_tests {
+    use sui::test_scenario::{Self, Scenario};
+    use liquid_staking::fees::{Self};
+    use liquid_staking::liquid_staking::{Self};
+    use sui::coin::{Self};
+    use liquid_staking::weight::{Self};
+    use liquid_staking::registry::{Self};
+    public struct TEST has drop {}
+
+     #[test]
+     fun test_add_weight_hook_to_registry() {
+        let mut scenario = test_scenario::begin(@0x0);
+
+        let (admin_cap, lst_info) = liquid_staking::create_lst<TEST>(
+            fees::new_builder(scenario.ctx()).to_fee_config(),
+            coin::create_treasury_cap_for_testing(scenario.ctx()),
+            scenario.ctx()
+        );
+
+        let admin_cap_id = object::id(&admin_cap);
+        let lst_info_id = object::id(&lst_info);
+
+        let (weight_hook, weight_hook_admin_cap) = weight::new(admin_cap, scenario.ctx());
+
+        let mut registry = registry::new(scenario.ctx());
+        weight_hook.add_to_registry(&mut registry, &lst_info);
+
+        let entry = registry::get_entry<TEST, weight::RegistryInfo>(&registry);
+        assert!(entry.admin_cap_id() == admin_cap_id);
+        assert!(entry.liquid_staking_info_id() == lst_info_id);
+        assert!(entry.extra_info().weight_hook_id() == object::id(&weight_hook));
+
+        sui::test_utils::destroy(lst_info);
+        sui::test_utils::destroy(weight_hook);
+        sui::test_utils::destroy(weight_hook_admin_cap);
+        sui::test_utils::destroy(registry);
+
+        scenario.end();
+    }
+}


### PR DESCRIPTION
1. create a registry module that tracks all LSTs. Since we've already published the liquid staking package, we can't use the module initializer to ensure that there's only 1 global Registry struct. However I don't think it's a huge deal. 
2. Emit an event when the weight hook is created 