### PR TITLE
custom unstake algo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,4 +21,4 @@ jobs:
         run: apt-get install -y git
 
       - name: test
-        run: cd contracts && sui move test
+        run: cd contracts && sui move test --gas-limit 5000000000000

--- a/contracts/sources/fees.move
+++ b/contracts/sources/fees.move
@@ -157,6 +157,15 @@ module liquid_staking::fees {
         (((sui_amount as u128) * (self.redeem_fee_bps as u128) + 9999) / 10_000) as u64
     }
 
+    public(package) fun calculate_custom_redeem_fee(self: &FeeConfig, sui_amount: u64): u64 {
+        if (self.custom_redeem_fee_bps == 0) {
+            return 0
+        };
+
+        // ceil(sui_amount * custom_redeem_fee_bps / 10_000)
+        (((sui_amount as u128) * (self.custom_redeem_fee_bps as u128) + 9999) / 10_000) as u64
+    }
+
     #[test_only] use sui::test_scenario::{Self, Scenario};
 
     #[test]

--- a/contracts/sources/hooks/weight.move
+++ b/contracts/sources/hooks/weight.move
@@ -6,6 +6,7 @@ module liquid_staking::weight {
     use liquid_staking::fees::{FeeConfig};
     use sui::vec_map::{Self, VecMap};
     use sui::bag::{Self, Bag};
+    use liquid_staking::liquid_staking::{CustomRedeemRequest};
     use liquid_staking::version::{Self, Version};
     use sui::package;
     use sui::coin::Coin;
@@ -96,12 +97,39 @@ module liquid_staking::weight {
         liquid_staking_info: &mut LiquidStakingInfo<P>,
         ctx: &mut TxContext
     ) {
+        liquid_staking_info.refresh(system_state, ctx);
+        let total_sui_supply = liquid_staking_info.storage().total_sui_supply(); // we want to allocate the unaccrued spread fees as well
+
+        self.rebalance_internal(system_state, liquid_staking_info, total_sui_supply, ctx)
+    }
+
+    public fun handle_custom_redeem_request<P>(
+        self: &mut WeightHook<P>,
+        system_state: &mut SuiSystemState,
+        liquid_staking_info: &mut LiquidStakingInfo<P>,
+        request: &CustomRedeemRequest<P>,
+        ctx: &mut TxContext
+    ) {
+        liquid_staking_info.refresh(system_state, ctx);
+
+        let total_sui_supply = liquid_staking_info.storage().total_sui_supply(); // we want to allocate the unaccrued spread fees as well
+        let sui_unstake_amount = liquid_staking_info.lst_amount_to_sui_amount(request.lst().value());
+        let total_sui_to_allocate = total_sui_supply - sui_unstake_amount;
+
+        self.rebalance_internal(system_state, liquid_staking_info, total_sui_to_allocate, ctx)
+    }
+
+    fun rebalance_internal<P>(
+        self: &mut WeightHook<P>,
+        system_state: &mut SuiSystemState,
+        liquid_staking_info: &mut LiquidStakingInfo<P>,
+        total_sui_to_allocate: u64,
+        ctx: &mut TxContext
+    ) {
         self.version.assert_version_and_upgrade(CURRENT_VERSION);
         if (self.total_weight == 0) {
             return
         };
-
-        liquid_staking_info.refresh(system_state, ctx);
 
         let mut validator_addresses_and_weights = self.validator_addresses_and_weights;
 
@@ -116,10 +144,8 @@ module liquid_staking::weight {
         // 2. calculate current and target amounts of sui for each validator
         let (validator_addresses, validator_weights) = validator_addresses_and_weights.into_keys_values();
 
-        let total_sui_supply = liquid_staking_info.storage().total_sui_supply(); // we want to allocate the unaccrued spread fees as well
-
         let validator_target_amounts  = validator_weights.map!(|weight| {
-            ((total_sui_supply as u128) * (weight as u128) / (self.total_weight as u128)) as u64
+            ((total_sui_to_allocate as u128) * (weight as u128) / (self.total_weight as u128)) as u64
         });
 
         let validator_current_amounts = validator_addresses.map_ref!(|validator_address| {

--- a/contracts/sources/hooks/weight.move
+++ b/contracts/sources/hooks/weight.move
@@ -107,7 +107,7 @@ module liquid_staking::weight {
         self: &mut WeightHook<P>,
         system_state: &mut SuiSystemState,
         liquid_staking_info: &mut LiquidStakingInfo<P>,
-        request: &CustomRedeemRequest<P>,
+        request: &mut CustomRedeemRequest<P>,
         ctx: &mut TxContext
     ) {
         liquid_staking_info.refresh(system_state, ctx);
@@ -116,7 +116,8 @@ module liquid_staking::weight {
         let sui_unstake_amount = liquid_staking_info.lst_amount_to_sui_amount(request.lst().value());
         let total_sui_to_allocate = total_sui_supply - sui_unstake_amount;
 
-        self.rebalance_internal(system_state, liquid_staking_info, total_sui_to_allocate, ctx)
+        self.rebalance_internal(system_state, liquid_staking_info, total_sui_to_allocate, ctx);
+        self.admin_cap.mark_redeem_request_as_processed(request);
     }
 
     fun rebalance_internal<P>(

--- a/contracts/sources/liquid_staking.move
+++ b/contracts/sources/liquid_staking.move
@@ -44,6 +44,12 @@ module liquid_staking::liquid_staking {
         id: UID
     }
 
+    /// hot potato that indicates a custom redeem request
+    #[allow(lint(coin_field))]
+    public struct CustomRedeemRequest<phantom P> {
+        lst: Coin<P>,
+    }
+
     /* Events */
     public struct CreateEvent has copy, drop {
         typename: TypeName,
@@ -111,6 +117,10 @@ module liquid_staking::liquid_staking {
 
     public fun fee_config<P>(self: &LiquidStakingInfo<P>): &FeeConfig {
         self.fee_config.get()
+    }
+
+    public fun lst<P>(self: &CustomRedeemRequest<P>): &Coin<P> {
+        &self.lst
     }
 
     #[test_only]
@@ -257,16 +267,34 @@ module liquid_staking::liquid_staking {
         system_state: &mut SuiSystemState, 
         ctx: &mut TxContext
     ): Coin<SUI> {
+        self.redeem_internal(lst, system_state, false, ctx)
+    }
+
+    fun redeem_internal<P: drop>(
+        self: &mut LiquidStakingInfo<P>,
+        lst: Coin<P>,
+        system_state: &mut SuiSystemState, 
+        is_custom_redeem: bool,
+        ctx: &mut TxContext
+    ): Coin<SUI> {
         self.refresh(system_state, ctx);
 
         let old_sui_supply = (self.total_sui_supply() as u128);
         let old_lst_supply = (self.total_lst_supply() as u128);
 
         let sui_amount_out = self.lst_amount_to_sui_amount(lst.value());
-        let mut sui = self.storage.split_n_sui(system_state, sui_amount_out, ctx);
+        let mut sui = if (is_custom_redeem) {
+            self.storage.split_up_to_n_sui_from_sui_pool(sui_amount_out)
+        } else {
+            self.storage.split_n_sui(system_state, sui_amount_out, ctx)
+        };
 
         // deduct fee
-        let redeem_fee_amount = self.fee_config.get().calculate_redeem_fee(sui.value());
+        let redeem_fee_amount = if (is_custom_redeem) {
+            self.fee_config.get().calculate_custom_redeem_fee(sui.value())
+        } else {
+            self.fee_config.get().calculate_redeem_fee(sui.value())
+        };
         self.fees.join(sui.split(redeem_fee_amount as u64));
 
         emit_event(RedeemEvent {
@@ -288,6 +316,27 @@ module liquid_staking::liquid_staking {
         coin::from_balance(sui, ctx)
     }
 
+    public fun custom_redeem_request<P: drop>(
+        self: &mut LiquidStakingInfo<P>,
+        lst: Coin<P>,
+        system_state: &mut SuiSystemState,
+        ctx: &mut TxContext
+    ): CustomRedeemRequest<P> {
+        self.version.assert_version_and_upgrade(CURRENT_VERSION);
+        self.refresh(system_state, ctx);
+
+        CustomRedeemRequest { lst }
+    }
+
+    public fun custom_redeem<P: drop>(
+        self: &mut LiquidStakingInfo<P>,
+        request: CustomRedeemRequest<P>,
+        system_state: &mut SuiSystemState, 
+        ctx: &mut TxContext
+    ): Coin<SUI> {
+        let CustomRedeemRequest { lst } = request;
+        self.redeem_internal(lst, system_state, true, ctx)
+    }
 
     // Admin Functions
     public fun change_validator_priority<P>(
@@ -456,7 +505,7 @@ module liquid_staking::liquid_staking {
         lst_amount as u64
     }
 
-    fun lst_amount_to_sui_amount<P>(
+    public(package) fun lst_amount_to_sui_amount<P>(
         self: &LiquidStakingInfo<P>, 
         lst_amount: u64
     ): u64 {

--- a/contracts/sources/liquid_staking.move
+++ b/contracts/sources/liquid_staking.move
@@ -284,7 +284,9 @@ module liquid_staking::liquid_staking {
 
         let sui_amount_out = self.lst_amount_to_sui_amount(lst.value());
         let mut sui = if (is_custom_redeem) {
-            self.storage.split_up_to_n_sui_from_sui_pool(sui_amount_out)
+            // the hook is responsible for unstakeingenough from the validators, so here we only
+            // take from the sui pool, and error otherwise.
+            self.storage.split_from_sui_pool(sui_amount_out)
         } else {
             self.storage.split_n_sui(system_state, sui_amount_out, ctx)
         };

--- a/contracts/sources/storage.move
+++ b/contracts/sources/storage.move
@@ -335,7 +335,7 @@ module liquid_staking::storage {
         self.split_from_sui_pool(sui_amount_out)
     }
 
-    fun split_from_sui_pool(self: &mut Storage, amount: u64): Balance<SUI> {
+    public(package) fun split_from_sui_pool(self: &mut Storage, amount: u64): Balance<SUI> {
         self.total_sui_supply = self.total_sui_supply - amount;
         self.sui_pool.split(amount)
     }

--- a/contracts/tests/weight_tests.move
+++ b/contracts/tests/weight_tests.move
@@ -134,4 +134,66 @@ module liquid_staking::weight_tests {
 
         scenario.end(); 
      }
+
+     #[test]
+     fun test_custom_redeem_request() {
+        let mut scenario = test_scenario::begin(@0x0);
+
+        setup_sui_system(&mut scenario, vector[100, 100, 100]);
+        scenario.next_tx(@0x0);
+
+        let (admin_cap, mut lst_info) = create_lst<TEST>(
+            fees::new_builder(scenario.ctx()).set_custom_redeem_fee_bps(100).to_fee_config(),
+            coin::create_treasury_cap_for_testing(scenario.ctx()),
+            scenario.ctx()
+        );
+
+        let mut system_state = scenario.take_shared<SuiSystemState>();
+        let sui = coin::mint_for_testing(100 * MIST_PER_SUI, scenario.ctx());
+        let mut lst = lst_info.mint(&mut system_state, sui, scenario.ctx());
+
+        assert!(lst_info.total_lst_supply() == 100 * MIST_PER_SUI, 0);
+        assert!(lst_info.storage().total_sui_supply() == 100 * MIST_PER_SUI, 0);
+
+        let (mut weight_hook, weight_hook_admin_cap) = weight::new(admin_cap, scenario.ctx());
+
+        weight_hook.set_validator_addresses_and_weights(
+            &weight_hook_admin_cap, 
+            {
+                let mut map = vec_map::empty();
+                map.insert(address::from_u256(0), 100);
+                map.insert(address::from_u256(1), 300);
+
+                map
+            }
+        );
+
+        weight_hook.rebalance(&mut system_state, &mut lst_info, scenario.ctx());
+
+        std::debug::print(lst_info.storage().validators());
+
+        assert!(lst_info.storage().validators().borrow(0).total_sui_amount() == 25 * MIST_PER_SUI, 0);
+        assert!(lst_info.storage().validators().borrow(1).total_sui_amount() == 75 * MIST_PER_SUI, 0);
+
+        let lst_to_unstake = lst.split(10 * MIST_PER_SUI, scenario.ctx());
+        let custom_redeem_request = lst_info.custom_redeem_request(lst_to_unstake,&mut system_state, scenario.ctx());
+        weight_hook.handle_custom_redeem_request(&mut system_state, &mut lst_info, &custom_redeem_request, scenario.ctx());
+
+        std::debug::print(lst_info.storage().validators());
+        assert!(lst_info.storage().validators().borrow(0).total_sui_amount() == 25 * MIST_PER_SUI - 2_500_000_000, 0);
+        assert!(lst_info.storage().validators().borrow(1).total_sui_amount() == 75 * MIST_PER_SUI - 7_500_000_000, 0);
+
+        let sui = lst_info.custom_redeem(custom_redeem_request, &mut system_state, scenario.ctx());
+        assert!(sui.value() == 10 * MIST_PER_SUI - 100_000_000, 0); // 0.1 sui fee
+
+        test_scenario::return_shared(system_state);
+
+        sui::test_utils::destroy(weight_hook);
+        sui::test_utils::destroy(weight_hook_admin_cap);
+        sui::test_utils::destroy(lst_info);
+        sui::test_utils::destroy(lst);
+        sui::test_utils::destroy(sui);
+
+        scenario.end(); 
+     }
 }

--- a/contracts/tests/weight_tests.move
+++ b/contracts/tests/weight_tests.move
@@ -176,10 +176,10 @@ module liquid_staking::weight_tests {
         assert!(lst_info.storage().validators().borrow(1).total_sui_amount() == 75 * MIST_PER_SUI, 0);
 
         let lst_to_unstake = lst.split(10 * MIST_PER_SUI, scenario.ctx());
-        let custom_redeem_request = lst_info.custom_redeem_request(lst_to_unstake,&mut system_state, scenario.ctx());
-        weight_hook.handle_custom_redeem_request(&mut system_state, &mut lst_info, &custom_redeem_request, scenario.ctx());
+        let mut custom_redeem_request = lst_info.custom_redeem_request(lst_to_unstake,&mut system_state, scenario.ctx());
+        weight_hook.handle_custom_redeem_request(&mut system_state, &mut lst_info, &mut custom_redeem_request, scenario.ctx());
 
-        std::debug::print(lst_info.storage().validators());
+        // std::debug::print(lst_info.storage().validators());
         assert!(lst_info.storage().validators().borrow(0).total_sui_amount() == 25 * MIST_PER_SUI - 2_500_000_000, 0);
         assert!(lst_info.storage().validators().borrow(1).total_sui_amount() == 75 * MIST_PER_SUI - 7_500_000_000, 0);
 


### PR DESCRIPTION
Allow each hook to define a custom unstaking algorithm. This way, different LSTs can have different unstaking behaviour. 

Note that unstaking via `liquid_staking::redeem` will still work, however the admin can set different fees on the two unstaking flows to incentivize what they want.

Default unstaking flow (which still works!):
```rust
let sui = liquid_staking::redeem(&mut system_stat, liquid_staking_info, lst, scenario.ctx());
```

New custom unstaking flow 
```rust
let custom_redeem_request = lst_info.custom_redeem_request(lst_to_unstake,&mut system_state, scenario.ctx());
weight_hook.handle_custom_redeem_request(&mut system_state, &mut lst_info, &custom_redeem_request, scenario.ctx());
let sui = lst_info.custom_redeem(custom_redeem_request, &mut system_state, scenario.ctx());
```